### PR TITLE
Add pipeline support, with two basic filters (fixes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ data = {
 }
 
 Pope.pope(
-  "The user {{user.username}} with id {{user.id}} is cool",
+  "The user {{user.username | upper}} with id {{user.id}} is cool",
   data
-) # "The user krthr with id 123 is cool"
+) # "The user KRTHR with id 123 is cool"
+
 
 Pope.prop(data, "user.id")           #  123
 Pope.prop(data, "user.config.email") # test@test.com
@@ -51,6 +52,17 @@ Pope.prop(data, "nananana")          # nil
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+### How to add additional filters Adding more filters is fairly straightforward:
+
+1. Add another member to the `Filters` enum in `src/pope.cr`
+
+2. Update the `Filters` enum class's static `parse` method to add a case for your filter's string identifier (so `"upper"` for the `Upper` filter, for example)
+
+3. Update the `Filters` enum class's `apply` instance method to actually do the necessary value transformation(s)
+
+4. Add tests for your new filter(s) (see `spec/pope_spec.cr` for examples)
+
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Pope.prop(data, "nananana")          # nil
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
-### How to add additional filters Adding more filters is fairly straightforward:
+### How to add additional filters
+
+Adding more filters is fairly straightforward:
 
 1. Add another member to the `Filters` enum in `src/pope.cr`
 

--- a/spec/pope_spec.cr
+++ b/spec/pope_spec.cr
@@ -30,4 +30,98 @@ describe Pope do
       end
     end
   end
+
+  describe "#pope" do 
+    it "no-ops on strings without template expressions" do
+      data = {
+        name: NAME,
+      }
+      input = "this is a test, yay!"   
+      
+      result = Pope.pope(input, data)
+      result.should eq input
+    end
+
+    it "evaluates strings that only consist of a template expression" do
+      data = {
+        name: NAME,
+      }
+
+      input = "{{name}}"   
+      
+      result = Pope.pope(input, data)
+      result.should eq NAME
+    end
+
+    it "evaluates strings that have a mix of template expressions and non-template-expression constant strings" do
+      data = {
+        name: NAME,
+        age: 42
+      }
+
+      input = "My name is {{name}} and I am {{age}} years old"
+      
+      result = Pope.pope(input, data)
+      result.should eq "My name is #{data[:name]} and I am #{data[:age]} years old"
+    end
+
+    describe "with filters" do 
+      it "applies the upper filter correctly" do 
+        data = {
+          name: NAME,
+        }
+
+        result = Pope.pope("Your name is {{name | upper}}", data)
+        result.should eq "Your name is #{NAME.upcase}"
+      end
+
+      it "applies the lower filter correctly" do 
+        data = {
+          name: NAME,
+        }
+
+        result = Pope.pope("Your name is {{name | lower}}", data)
+        result.should eq "Your name is #{NAME.downcase}"
+      end
+
+      it "applies multiple filters in the same expression correctly" do
+        data = {
+          name: NAME,
+        }
+
+        result = Pope.pope("Your name is {{name | lower | upper}}", data)
+        result.should eq "Your name is #{NAME.downcase.upcase}"
+      end
+
+      it "applies multiple filters in different expressions correctly" do
+        data = {
+          name: NAME,
+          title: "Programmer"
+        }
+
+        result = Pope.pope("Your name is {{name | lower}}, and you're a {{title | upper}}", data)
+        result.should eq "Your name is #{NAME.downcase}, and you're a #{data[:title].upcase}"
+      end
+
+      it "raises an exception when an unrecognized filter is specified" do
+        data = {
+          name: NAME
+        }
+
+        expect_raises(Pope::InvalidFilter, "Invalid filter: 'fakenotrealfilter'") do 
+          Pope.pope("Test fake filter: {{name | fakenotrealfilter}}", data)
+        end
+      end
+
+      it "raises an exception when a filter expression is incorrectly terminated" do
+        data = {
+          name: NAME
+        }
+
+        expect_raises(Pope::InvalidFilter, "Invalid filter: ''") do 
+          Pope.pope("Test fake filter: {{name | }}", data)
+        end
+      end
+    end
+  end
 end

--- a/src/pope.cr
+++ b/src/pope.cr
@@ -132,8 +132,7 @@ module Pope
         end
 
         if opts[:skip_undefined]
-          val = str
-          next # if we didn't find the value, but we're supposed to skip unresolved values, then don't apply filters either.
+          next str # if we didn't find the value, but we're supposed to skip unresolved values, then don't apply filters either.
         end
       end
 

--- a/src/pope.cr
+++ b/src/pope.cr
@@ -12,6 +12,47 @@ module Pope
     end
   end
 
+  class InvalidFilter < Exception
+    def initialize(filter_name : String?)
+      super "Invalid filter: '#{filter_name}'"
+    end
+  end
+
+  # The supported filters for template expressions.
+  # For example:
+  # ```
+  # data = { name: "Monty Python" }
+  # Pope.pope("Your name is {{name | upper}}")  # Your name is MONTY PYTHON
+  # ```
+  enum Filters
+    Upper
+    Lower
+
+    def self.parse(input : String?)
+      raise InvalidFilter.new(input) unless input
+
+      case input.downcase
+      when "upper" then Upper
+      when "lower" then Lower
+      else raise InvalidFilter.new(input)
+      end
+    end
+
+    def apply(value)
+      case self
+      when Upper then value.to_s.upcase
+      when Lower then value.to_s.downcase
+      end
+    end
+  end
+
+  # apply a series of filters to a given value, in order
+  def self.apply_filters(value, filters : Array(Filters))
+    filters.reduce(value) do |current, filter|
+      filter.apply(current)
+    end
+  end
+
   # get nested properties from a given object using dot notation
   #
   # ```
@@ -30,9 +71,9 @@ module Pope
   # Pope.prop(data, "nananana")          # nil
   # ```
   def self.prop(obj : NamedTuple | Hash, path : String = "")
-    raise MissinPath.new unless path != ""
+    raise MissinPath.new unless path.strip != ""
 
-    props = path.split(".")
+    props = path.strip.split(".")
 
     i = 0
     while i < props.size && !obj.nil?
@@ -70,8 +111,18 @@ module Pope
       throw_on_undefined: false,
     }
   )
+    # Grab out all template expressions to evaluate and replace
     string.gsub(/{{2}(.+?)}{2}/) do |str, match|
-      path = match[1]
+      expression = match[1]
+      # Look for any pipeline filters that may be applied
+      path_and_all_filters = expression.split("|")
+      path = path_and_all_filters[0]
+      filters = 
+        if path_and_all_filters.size > 1 
+          path_and_all_filters.skip(1).map(&.strip).map {|it| Filters.parse(it)}
+        else
+          [] of Filters
+        end
 
       val = self.prop(data, path)
 
@@ -82,10 +133,11 @@ module Pope
 
         if opts[:skip_undefined]
           val = str
+          next # if we didn't find the value, but we're supposed to skip unresolved values, then don't apply filters either.
         end
       end
 
-      val
+      self.apply_filters(val, filters)
     end
   end
 end


### PR DESCRIPTION
I added the `upper` and `lower` filters demonstrated in your example, and also added a few more spec tests around both them and the `Pope.pope` method in general.

### How do I extend this to add more filters?

Adding more filters is fairly straightforward:

1. Add another member to the `Filters` enum: https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L27-L29

2. Update the `Filters` enum class's static `parse` method to parse it out (though this could possibly be simplified by just string-matching on the enum case names): https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L31-L39

3. Update the `Filters` enum class's `apply` instance method to actually do the necessary value transformation(s): https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L41-L46

4. Add tests for your new filter(s): https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/spec/pope_spec.cr#L68-L85

### How does the filter processing work?

The filter processing is done within the existing `gsub` call in `Pope.pope`. We treat the contents of each double-curly-brace segment as an "expression" rather than just a path on its own, and we attempt to identify the phases of the pipeline by splitting on the pipeline-phase delimiter `|` and assuming that they should be evaluated left-to-right, starting with the actual path as the leftmost element (to be resolved against the provided data structure), and proceeding with filters in each subsequent "phase":

https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L116-L125

Notably, since this step calls `Filters.parse`, any unrecognized filter string will be immediately identified and will result in throwing an `InvalidFilter` exception:
https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L31-L39

Having parsed out our pipeline into a path expression and an ordered series of filters to apply, we look up the path from the data structure, and, assuming we get a value back, we then apply the filters to it, one after the other from "left to right" as they appear in the pipeline expression:

https://github.com/krthr/pope.cr/blob/506c2bcafe80c3a61aab77bc76b2241cad6114fa/src/pope.cr#L127-L139

(the `self.apply_filters` there is a call to this method: ) https://github.com/krthr/pope.cr/blob/a9d8aeab736f71c285b69fae426c0bf04b42d428/src/pope.cr#L49-L54

This call to `self.apply_filters` is the last line of the block passed to `gsub`, so whatever that method returns is yielded back to `gsub` to be used as a replacement for the original double-curly-braces expression (so `{{name | upper}}` is replaced with `SPENCER`, for example).